### PR TITLE
Feature: Global variable probing in WAMR

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1203,6 +1203,7 @@ AOTGlobal *
 aot_lookup_global(const AOTModuleInstance *module_inst, const char *name)
 {
     uint32 i;
+    // AOTExportGlobal is analogous of WASMExportGlobInstance
     AOTExportGlobal *export_globals =
         (AOTExportGlobal *)module_inst->export_globals.ptr;
 

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -525,6 +525,21 @@ aot_deinstantiate(AOTModuleInstance *module_inst, bool is_sub_inst);
 AOTFunctionInstance *
 aot_lookup_function(const AOTModuleInstance *module_inst, const char *name,
                     const char *signature);
+
+/**
+ * Lookup an exported global in the AOT module instance.
+ *
+ * @param module_inst the module instance
+ * @param name the name of the function
+ * @param signature the signature of the function, use "i32"/"i64"/"f32"/"f64"
+ *        to represent the type of i32/i64/f32/f64, e.g. "(i32i64)" "(i32)f32"
+ *
+ * @return the function instance found
+ */
+AOTGlobal *
+aot_lookup_global(const AOTModuleInstance *module_inst, const char *name);
+
+
 /**
  * Call the given AOT function of a AOT module instance with
  * arguments.

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1198,6 +1198,51 @@ wasm_runtime_lookup_function(WASMModuleInstanceCommon *const module_inst,
     return NULL;
 }
 
+
+WASMGlobalInstanceCommon *
+wasm_runtime_lookup_global(WASMModuleInstanceCommon *const module_inst,
+                             const char *name)
+{
+#if WASM_ENABLE_INTERP != 0
+    if (module_inst->module_type == Wasm_Module_Bytecode) {
+      //printf("In the WASM CODE!\n");
+      const WASMModuleInstance* mod_inst = (const WASMModuleInstance*) module_inst;
+      for (uint32 i = 0; i < mod_inst->export_glob_count; i++) {
+        //printf("EXPORT GLOBAL: %s\n", mod_inst->export_globals[i].name);
+        //printf("Addr: %p\n", mod_inst->export_globals[i].global);
+      }
+
+      WASMGlobalInstance *global_inst = wasm_lookup_global(mod_inst, name);
+      if (global_inst) {
+        //uint8* global_addr = get_global_addr(mod_inst->global_data, global_inst);
+        //printf("Addr OOB: %p\n", global_inst);
+        if (!(global_inst->import_global_inst)) {
+          printf("No global insts!\n");
+        } else {
+          printf("Global insts!\n");
+        }
+        uint8* global_addr = mod_inst->global_data + global_inst->data_offset;
+        //printf("Addr with offset: %p\n", global_addr);
+        // global_addr gives the index in the data segment
+        printf("Value at Addr: %d\n", *((int32*) global_addr));
+        // index into memory data
+        uint8* global_data_addr = mod_inst->default_memory->memory_data + (*((int32*) global_addr));
+        printf("Value at Data Addr: %x\n", *((int32*) global_data_addr));
+      }
+    }
+#endif
+/*
+#if WASM_ENABLE_AOT != 0
+    if (module_inst->module_type == Wasm_Module_AoT)
+        return (WASMGlobalInstanceCommon *)aot_lookup_global(
+            (const AOTModuleInstance *)module_inst, name);
+#endif
+*/
+    return NULL;
+}
+
+
+
 #if WASM_ENABLE_REF_TYPES != 0
 /* (uintptr_t)externref -> (uint32_t)index */
 /*   argv               ->   *ret_argv */

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1205,7 +1205,6 @@ wasm_runtime_lookup_global(WASMModuleInstanceCommon *const module_inst,
 {
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode) {
-      //printf("In the WASM CODE!\n");
       const WASMModuleInstance* mod_inst = (const WASMModuleInstance*) module_inst;
       for (uint32 i = 0; i < mod_inst->export_glob_count; i++) {
         //printf("EXPORT GLOBAL: %s\n", mod_inst->export_globals[i].name);
@@ -1216,28 +1215,49 @@ wasm_runtime_lookup_global(WASMModuleInstanceCommon *const module_inst,
       if (global_inst) {
         //uint8* global_addr = get_global_addr(mod_inst->global_data, global_inst);
         //printf("Addr OOB: %p\n", global_inst);
-        if (!(global_inst->import_global_inst)) {
-          printf("No global insts!\n");
-        } else {
-          printf("Global insts!\n");
-        }
+        //
         uint8* global_addr = mod_inst->global_data + global_inst->data_offset;
         //printf("Addr with offset: %p\n", global_addr);
         // global_addr gives the index in the data segment
         printf("Value at Addr: %d\n", *((int32*) global_addr));
         // index into memory data
         uint8* global_data_addr = mod_inst->default_memory->memory_data + (*((int32*) global_addr));
-        printf("Value at Data Addr: %x\n", *((int32*) global_data_addr));
+        printf("Value at Data Addr: %d\n", *((uint32*) global_data_addr));
       }
     }
 #endif
-/*
 #if WASM_ENABLE_AOT != 0
-    if (module_inst->module_type == Wasm_Module_AoT)
-        return (WASMGlobalInstanceCommon *)aot_lookup_global(
-            (const AOTModuleInstance *)module_inst, name);
+    if (module_inst->module_type == Wasm_Module_AoT) {
+      const AOTModuleInstance* mod_inst = (const AOTModuleInstance*) module_inst;
+      printf("Number of Export Globals (AOT): %d\n", mod_inst->export_global_count);
+      printf("Number of Export Total (AOT): %d\n", ((AOTModule*)(mod_inst->aot_module.ptr))->export_count);
+      printf("Number of Global Total (AOT): %d\n", ((AOTModule*)(mod_inst->aot_module.ptr))->global_count);
+      printf("Memory Count (AOT): %d\n", mod_inst->memory_count);
+
+      // AOTExportGlobal is analogous of WASMExportGlobInstance
+      AOTExportGlobal* exp_globals = (AOTExportGlobal*) mod_inst->export_globals.ptr;
+
+      for (uint32 i = 0; i < mod_inst->export_global_count; i++) {
+        printf("EXPORT GLOBAL: %s\n", exp_globals[i].name);
+        printf("Addr: %p\n", exp_globals[i].global);
+      }
+
+      AOTGlobal *global_inst = aot_lookup_global(mod_inst, name);
+      if (global_inst) {
+        printf("Global Inst offset: %d\n", global_inst->data_offset);
+        //uint8* global_addr = get_global_addr(mod_inst->global_data, global_inst);
+        //printf("Addr OOB: %p\n", global_inst);
+        //
+        uint8* global_addr = mod_inst->global_data.ptr + global_inst->data_offset;
+        //printf("Addr with offset: %p\n", global_addr);
+        // global_addr gives the index in the data segment
+        printf("Value at Addr: %d\n", *((int32*) global_addr));
+        // index into memory data
+        uint8* global_data_addr = mod_inst->global_table_data.memory_instances->memory_data.ptr + (*((int32*) global_addr));
+        printf("Value at Data Addr: %d\n", *((uint32*) global_data_addr));
+      }
+    }
 #endif
-*/
     return NULL;
 }
 

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1206,55 +1206,33 @@ wasm_runtime_lookup_global(WASMModuleInstanceCommon *const module_inst,
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode) {
       const WASMModuleInstance* mod_inst = (const WASMModuleInstance*) module_inst;
-      for (uint32 i = 0; i < mod_inst->export_glob_count; i++) {
-        //printf("EXPORT GLOBAL: %s\n", mod_inst->export_globals[i].name);
-        //printf("Addr: %p\n", mod_inst->export_globals[i].global);
-      }
 
       WASMGlobalInstance *global_inst = wasm_lookup_global(mod_inst, name);
       if (global_inst) {
-        //uint8* global_addr = get_global_addr(mod_inst->global_data, global_inst);
-        //printf("Addr OOB: %p\n", global_inst);
-        //
-        uint8* global_addr = mod_inst->global_data + global_inst->data_offset;
-        //printf("Addr with offset: %p\n", global_addr);
         // global_addr gives the index in the data segment
-        printf("Value at Addr: %d\n", *((int32*) global_addr));
+        uint8* global_addr = mod_inst->global_data + global_inst->data_offset;
         // index into memory data
-        uint8* global_data_addr = mod_inst->default_memory->memory_data + (*((int32*) global_addr));
-        printf("Value at Data Addr: %d\n", *((uint32*) global_data_addr));
+        uint8* global_data_addr = mod_inst->default_memory->memory_data + (*((uint32*) global_addr));
+        return (WASMGlobalInstanceCommon*) global_data_addr;
       }
     }
 #endif
 #if WASM_ENABLE_AOT != 0
     if (module_inst->module_type == Wasm_Module_AoT) {
       const AOTModuleInstance* mod_inst = (const AOTModuleInstance*) module_inst;
-      printf("Number of Export Globals (AOT): %d\n", mod_inst->export_global_count);
+      /*printf("Number of Export Globals (AOT): %d\n", mod_inst->export_global_count);
       printf("Number of Export Total (AOT): %d\n", ((AOTModule*)(mod_inst->aot_module.ptr))->export_count);
       printf("Number of Global Total (AOT): %d\n", ((AOTModule*)(mod_inst->aot_module.ptr))->global_count);
       printf("Memory Count (AOT): %d\n", mod_inst->memory_count);
-
-      // AOTExportGlobal is analogous of WASMExportGlobInstance
-      AOTExportGlobal* exp_globals = (AOTExportGlobal*) mod_inst->export_globals.ptr;
-
-      for (uint32 i = 0; i < mod_inst->export_global_count; i++) {
-        printf("EXPORT GLOBAL: %s\n", exp_globals[i].name);
-        printf("Addr: %p\n", exp_globals[i].global);
-      }
+      */
 
       AOTGlobal *global_inst = aot_lookup_global(mod_inst, name);
       if (global_inst) {
-        printf("Global Inst offset: %d\n", global_inst->data_offset);
-        //uint8* global_addr = get_global_addr(mod_inst->global_data, global_inst);
-        //printf("Addr OOB: %p\n", global_inst);
-        //
-        uint8* global_addr = mod_inst->global_data.ptr + global_inst->data_offset;
-        //printf("Addr with offset: %p\n", global_addr);
         // global_addr gives the index in the data segment
-        printf("Value at Addr: %d\n", *((int32*) global_addr));
+        uint8* global_addr = mod_inst->global_data.ptr + global_inst->data_offset;
         // index into memory data
-        uint8* global_data_addr = mod_inst->global_table_data.memory_instances->memory_data.ptr + (*((int32*) global_addr));
-        printf("Value at Data Addr: %d\n", *((uint32*) global_data_addr));
+        uint8* global_data_addr = mod_inst->global_table_data.memory_instances->memory_data.ptr + (*((uint32*) global_addr));
+        return (WASMGlobalInstanceCommon*) global_data_addr;
       }
     }
 #endif

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -451,6 +451,11 @@ WASM_RUNTIME_API_EXTERN WASMFunctionInstanceCommon *
 wasm_runtime_lookup_function(WASMModuleInstanceCommon *const module_inst,
                              const char *name, const char *signature);
 
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN WASMFunctionInstanceCommon *
+wasm_runtime_lookup_global(WASMModuleInstanceCommon *const module_inst,
+                             const char *name);
+
 /* Internal API */
 WASMType *
 wasm_runtime_get_function_type(const WASMFunctionInstanceCommon *function,

--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -163,6 +163,14 @@ typedef struct AOTGlobal {
 } AOTGlobal;
 
 /**
+ * Export global variable
+ */
+typedef struct AOTExportGlobal {
+    char *name;
+    AOTGlobal *global;
+} AOTExportGlobal;
+
+/**
  * Import function
  */
 typedef struct AOTImportFunc {

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -66,10 +66,16 @@ typedef struct WASMModuleCommon *wasm_module_t;
 /* Instantiated WASM module */
 struct WASMModuleInstanceCommon;
 typedef struct WASMModuleInstanceCommon *wasm_module_inst_t;
+typedef const struct WASMModuleInstanceCommon *const_wasm_module_inst_t;
 
 /* Function instance */
 typedef void WASMFunctionInstanceCommon;
 typedef WASMFunctionInstanceCommon *wasm_function_inst_t;
+
+/* Global instance */
+typedef void WASMGlobalInstanceCommon;
+typedef WASMGlobalInstanceCommon *wasm_global_inst_t;
+
 
 /* WASM section */
 typedef struct wasm_section_t {
@@ -402,6 +408,22 @@ wasm_runtime_lookup_wasi_start_function(wasm_module_inst_t module_inst);
 WASM_RUNTIME_API_EXTERN wasm_function_inst_t
 wasm_runtime_lookup_function(wasm_module_inst_t const module_inst,
                              const char *name, const char *signature);
+
+
+/**
+ * Lookup an exported function in the WASM module instance.
+ *
+ * @param module_inst the module instance
+ * @param name the name of the function
+ * @param signature the signature of the function, ignored currently
+ *
+ * @return the function instance found, NULL if not found
+ */
+WASM_RUNTIME_API_EXTERN wasm_global_inst_t
+wasm_runtime_lookup_global(wasm_module_inst_t const module_inst,
+                             const char *name);
+
+
 
 /**
  * Create execution environment for a WASM module instance.
@@ -868,6 +890,11 @@ wasm_runtime_get_user_data(wasm_exec_env_t exec_env);
  */
 WASM_RUNTIME_API_EXTERN void
 wasm_runtime_dump_mem_consumption(wasm_exec_env_t exec_env);
+
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_dump_module_inst_mem_consumption(
+  const_wasm_module_inst_t module_inst);
+
 
 /**
  * Dump runtime performance profiler data of each function


### PR DESCRIPTION
Users of WAMR API can invoke `wasm_runtime_lookup_global (WASMModuleInstanceCommon* , char* name)` to obtain a pointer to the global variable 